### PR TITLE
Fix git home manager module

### DIFF
--- a/home-manager/modules/git.nix
+++ b/home-manager/modules/git.nix
@@ -1,14 +1,15 @@
-
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   programs.git = {
     enable = true;
-    userName = "Jerry Arciaga";
-    userEmail = "jerryarciaga11@gmail.com";
 
-    extraConfig = {
-      user.signingKey = "637B97EA39C4344993B20E4A28D9FAA9FA130F14";
+    settings = {
+      user = {
+        name = "Jerry Arciaga";
+        email = "jerryaricaga11@gmail.com";
+        signingKey = "637B97EA39C4344993B20E4A28D9FAA9FA130F14";
+      };
       core.sshCommand = "ssh -I /run/current-system/sw/lib/libykcs11.so";
       commit.gpgSign = true;
       init.defaultBranch = "main";


### PR DESCRIPTION
Some options in `home-manager` module `programs.git` have changed. Update `programs.git` options.
